### PR TITLE
fix(libdd-common): is_file_endpoint - changelog check should fail

### DIFF
--- a/libdd-common/src/lib.rs
+++ b/libdd-common/src/lib.rs
@@ -301,6 +301,7 @@ impl Endpoint {
     }
 
     pub fn is_file_endpoint(&self) -> bool {
+        print!("epa");
         self.url.scheme_str() == Some("file")
     }
 }


### PR DESCRIPTION
# What does this PR do?

Force a changelog check to fail, adding a fix to libdd-common and not including it in CHANGELOG.md